### PR TITLE
feat: enhance theme and expense cards

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1073,6 +1073,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 ...entry.value
                     .take(3)
                     .map((expense) => ExpenseTile(expense: expense)),
+                const SizedBox(height: 8),
               ],
           ],
         );

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -53,14 +53,13 @@ class AppTheme {
 
   // Main theme configuration
   static ThemeData theme(BuildContext context) => ThemeData(
+        useMaterial3: true,
         primaryColor: primaryGreen,
         scaffoldBackgroundColor: backgroundColor,
-        // Color scheme configuration
-        colorScheme: const ColorScheme.light(
-          primary: primaryGreen,
-          secondary: lightGreen,
-          surface: backgroundColor,
-          onPrimary: Colors.white,
+        // Color scheme configuration using a seeded scheme for easier theming
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: primaryGreen,
+          brightness: Brightness.light,
         ),
         // Text theme configuration
         textTheme: TextTheme(
@@ -83,6 +82,10 @@ class AppTheme {
             ),
             // Subtle elevation
             elevation: WidgetStateProperty.all(2),
+            // Additional padding for better tap targets on larger screens
+            padding: WidgetStateProperty.all(
+              const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            ),
             // Background color with press state
             backgroundColor: WidgetStateProperty.resolveWith((states) {
               if (states.contains(WidgetState.pressed)) {
@@ -106,13 +109,12 @@ class AppTheme {
       );
 
   static ThemeData darkTheme(BuildContext context) => ThemeData(
+        useMaterial3: true,
         primaryColor: darkPrimaryGreen,
         scaffoldBackgroundColor: darkBackgroundColor,
-        colorScheme: const ColorScheme.dark(
-          primary: darkPrimaryGreen,
-          secondary: darkLightGreen,
-          surface: darkBackgroundColor,
-          onPrimary: darkTextColor,
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: darkPrimaryGreen,
+          brightness: Brightness.dark,
         ),
         textTheme: TextTheme(
           headlineLarge: headlineLarge(context).copyWith(color: darkTextColor),
@@ -131,6 +133,9 @@ class AppTheme {
               ),
             ),
             elevation: WidgetStateProperty.all(2),
+            padding: WidgetStateProperty.all(
+              const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+            ),
             backgroundColor: WidgetStateProperty.resolveWith((states) {
               if (states.contains(WidgetState.pressed)) {
                 return darkDarkerGreen;

--- a/lib/widgets/expense_tile.dart
+++ b/lib/widgets/expense_tile.dart
@@ -44,40 +44,43 @@ class ExpenseTile extends StatelessWidget {
     final categoryService = Provider.of<CategoryService>(context, listen: false);
     final categoryName = categoryService.getCategoryNameById(expense.categoryId, defaultName: expense.categoryId);
 
-    return ListTile(
-      contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
-      leading: Container(
-        width: 40,
-        height: 40,
-        decoration: BoxDecoration(
-          color: AppColors.primary.withOpacity(0.1),
-          borderRadius: BorderRadius.circular(8),
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 4.0),
+      child: ListTile(
+        contentPadding: const EdgeInsets.symmetric(horizontal: 16.0),
+        leading: Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: AppColors.primary.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(8),
+          ),
+          child: Icon(
+            _getCategoryIcon(categoryName),
+            color: AppColors.primary,
+          ),
         ),
-        child: Icon(
-          _getCategoryIcon(categoryName),
-          color: AppColors.primary,
+        title: Text(
+          categoryName,
+          style: const TextStyle(
+            fontWeight: FontWeight.w500,
+          ),
         ),
-      ),
-      title: Text(
-        categoryName,
-        style: const TextStyle(
-          fontWeight: FontWeight.w500,
+        subtitle: Text(
+          expense.note ?? '',
+          style: TextStyle(
+            color: Colors.grey[600],
+            fontSize: 12,
+          ),
         ),
-      ),
-      subtitle: Text(
-        expense.note ?? '',
-        style: TextStyle(
-          color: Colors.grey[600],
-          fontSize: 12,
-        ),
-      ),
-      trailing: Text(
-        currencyFormat.format(expense.amount),
-        style: TextStyle(
-          color: expense.amount < 0 ? Colors.red : Colors.green,
-          fontWeight: FontWeight.w600,
+        trailing: Text(
+          currencyFormat.format(expense.amount),
+          style: TextStyle(
+            color: expense.amount < 0 ? Colors.red : Colors.green,
+            fontWeight: FontWeight.w600,
+          ),
         ),
       ),
     );
   }
-} 
+}


### PR DESCRIPTION
## Summary
- adopt Material 3 seeded color scheme with added button padding
- present recent expenses in card tiles for clearer scanning

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895dad581948327b671d92e237eaa41

## Summary by Sourcery

Enhance app theming and improve the presentation of expense items.

Enhancements:
- Enable Material3 and switch to seeded color schemes for both light and dark themes
- Add additional horizontal and vertical padding to buttons for better tap targets
- Wrap expense list tiles in Card widgets with consistent margins for clearer layout
- Insert spacing between recent expense cards in the dashboard for improved scanning